### PR TITLE
Unblock Pause Menu and adjust shotgun hitbox

### DIFF
--- a/jumpgun/Resources/Player/Resource_player_shotgun.tres
+++ b/jumpgun/Resources/Player/Resource_player_shotgun.tres
@@ -8,7 +8,7 @@
 script = ExtResource("1_lb1lt")
 gun_type = 1
 gun_model = ExtResource("2_50a0d")
-gun_hitbox = PackedVector2Array(-27, 6, -30, 0, -31, -5, -20, -6, -17, -5, -10, -7, 32, -7, 32, -4, -3, -4, -13, 2, -18, 2, -25, 6)
+gun_hitbox = PackedVector2Array(-28, 6, -31, 0, -31, -5, -20, -7, -17, -5, -11, -8, 33, -8, 33, -3, -2, -3, -13, 3, -18, 3, -25, 7)
 muzzle_location = Vector2(32, -6)
 full_auto = false
 shot_cooldown = 0.8

--- a/jumpgun/Scenes/player.tscn
+++ b/jumpgun/Scenes/player.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://Scripts/player.gd" id="1_dvgqa"]
 [ext_resource type="Texture2D" uid="uid://umclk13rlpwa" path="res://Import/Textures/temp-shotgun.png" id="2_fp8t6"]
-[ext_resource type="PackedScene" uid="uid://b726t2ao5hblb" path="res://Scenes/Particles/shotgun_smoke.tscn" id="2_xtojg"]
+[ext_resource type="PackedScene" uid="uid://counsjax6jdx4" path="res://Scenes/Particles/shotgun_smoke.tscn" id="2_xtojg"]
 [ext_resource type="Texture2D" uid="uid://ye4d0xhwryv4" path="res://Import/Textures/bullet.png" id="3_q0t7m"]
 [ext_resource type="PackedScene" uid="uid://ck8fw6x7e6mjo" path="res://Scenes/UI/hud.tscn" id="4_01w15"]
 
@@ -44,8 +44,9 @@ position = Vector2(14, -5)
 target_position = Vector2(-100, 0)
 collision_mask = 2
 
-[node name="PauseMenu" type="Control" parent="."]
-visible = false
+[node name="HUD" parent="." instance=ExtResource("4_01w15")]
+
+[node name="PauseMenu" type="Control" parent="HUD"]
 layout_mode = 3
 anchors_preset = 8
 anchor_left = 0.5
@@ -59,36 +60,34 @@ offset_bottom = 360.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="AspectRatioContainer" type="AspectRatioContainer" parent="PauseMenu"]
+[node name="AspectRatioContainer" type="AspectRatioContainer" parent="HUD/PauseMenu"]
 layout_mode = 0
 offset_right = 1280.0
 offset_bottom = 720.0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PauseMenu/AspectRatioContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="HUD/PauseMenu/AspectRatioContainer"]
 layout_mode = 2
 alignment = 1
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PauseMenu/AspectRatioContainer/HBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="HUD/PauseMenu/AspectRatioContainer/HBoxContainer"]
 layout_mode = 2
 theme_override_constants/separation = 20
 alignment = 1
 
-[node name="PauseLBL" type="Label" parent="PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer"]
+[node name="PauseLBL" type="Label" parent="HUD/PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 6
 theme_override_font_sizes/font_size = 48
 text = "PAUSED"
 
-[node name="ResumeBTN" type="Button" parent="PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer"]
+[node name="ResumeBTN" type="Button" parent="HUD/PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer"]
 layout_mode = 2
 text = "Resume"
 
-[node name="ReturnBTN" type="Button" parent="PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer"]
+[node name="ReturnBTN" type="Button" parent="HUD/PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer"]
 layout_mode = 2
 text = "Return to Level Select"
 
-[node name="HUD" parent="." instance=ExtResource("4_01w15")]
-
-[connection signal="pressed" from="PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer/ResumeBTN" to="." method="_on_resume_btn_pressed"]
-[connection signal="pressed" from="PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer/ReturnBTN" to="." method="_on_return_btn_pressed"]
+[connection signal="pressed" from="HUD/PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer/ResumeBTN" to="." method="_on_resume_btn_pressed"]
+[connection signal="pressed" from="HUD/PauseMenu/AspectRatioContainer/HBoxContainer/VBoxContainer/ReturnBTN" to="." method="_on_return_btn_pressed"]

--- a/jumpgun/Scripts/player.gd
+++ b/jumpgun/Scripts/player.gd
@@ -65,7 +65,7 @@ func _ready() -> void:
 	if gun_resource != null:
 		reloadResource()
 	$Gun/LaserSight.self_modulate = Color(1, 0, 0, 0)
-	$PauseMenu.hide()
+	$HUD/PauseMenu.hide()
 	slowdown = slowdown_seconds
 	currentMag = starting_ammo
 	HUDLayer = get_node("HUD")
@@ -267,10 +267,10 @@ func updateHUD():
 #Pausing/unpausing Functions
 func _on_level_base_pause() -> void:
 	isPaused = true
-	$PauseMenu.show()
+	$HUD/PauseMenu.show()
 func _on_level_base_unpause() -> void:
 	isPaused = false
-	$PauseMenu.hide()
+	$HUD/PauseMenu.hide()
 func _on_resume_btn_pressed() -> void:
 	unpause.emit()
 func _on_return_btn_pressed() -> void:


### PR DESCRIPTION
pause menu was "blocked" by the new HUD, so now I've moved it into being a child node of the HUD.

shotgun barrel hitbox was very narrow (2 pixels wide) and had a tendency to get stuck between tiles - Excalibur in stone except it's a shotgun.  solution: widened hitbox to outline, now it gets stuck at least less often.  this will need to be a consideration when we start updating the art assets.