### PR TITLE
target multihit fix

### DIFF
--- a/jumpgun/Scripts/Objects/target.gd
+++ b/jumpgun/Scripts/Objects/target.gd
@@ -2,7 +2,10 @@ extends StaticBody2D
 class_name Target
 
 signal targetHit()
+var isHit = false
 
 func Hit():
-	targetHit.emit()
-	queue_free()
+	if isHit == false:
+		isHit = true
+		targetHit.emit()
+		queue_free()


### PR DESCRIPTION
if a single target is hit by multiple bullets in one game tick, ALL of them would count as targets destroyed, despite only destroying one target.  shotgun would cause this a lot.

this fix makes a target check if it has already been hit.